### PR TITLE
Exclude CLAUDE.md from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ permalink: /blog/:year/:month/:day/:title/
 exclude:
   - README.md
   - readme.md
+  - CLAUDE.md
   - local/
   - Profile.pdf
   - workspace.code-workspace


### PR DESCRIPTION
CLAUDE.md contains a raw Liquid tag ({% for post in site.posts %}) in a code snippet that caused the GitHub Pages Jekyll build to fail.

https://claude.ai/code/session_017vuuH1eSMkTzT9FtJHR8jj